### PR TITLE
ci: trigger CI workflow when a release pull request is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - 'master'
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [opened, ready_for_review, review_requested]
 
 jobs:
   build:


### PR DESCRIPTION
It should trigger the CI when a release pull request is created