### PR TITLE
ci: simplify trigger workflow for Node.js CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches:
-      - 'master'
+    branches: ['master']
   pull_request:
-    types: [opened, ready_for_review, review_requested]
+    branches: ['master']
 
 jobs:
   build:


### PR DESCRIPTION
Always run the CI when a pull request has `master` as a base branch