### PR TITLE
fix: update module path on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "HTTP Status Map",
   "main": "dist/index.js",
-  "module": "dist/http-status.esm.js",
+  "module": "dist/http-response-status.esm.js",
   "typings": "dist/index.d.ts",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Fixing the following error raised by vite

```
✘ [ERROR] [plugin vite:dep-scan] Failed to resolve entry for package "http-response-status". The package may have incorrect main/module/exports specified in its package.json.
```